### PR TITLE
Remove unused import

### DIFF
--- a/birthday_bag_exporter.py
+++ b/birthday_bag_exporter.py
@@ -8,7 +8,6 @@ import subprocess
 import threading
 from openpyxl import load_workbook
 from openpyxl.styles import Border, Side, PatternFill, Font, Alignment
-from openpyxl.utils import get_column_letter
 
 # Check and install required packages
 def install_requirements():


### PR DESCRIPTION
## Summary
- clean up openpyxl import in `birthday_bag_exporter.py`
- ensure file ends with newline

## Testing
- `python -m py_compile birthday_bag_exporter.py`

------
https://chatgpt.com/codex/tasks/task_e_688172f02f2c832385160e56cbcdc0a6